### PR TITLE
Six second replication recipes

### DIFF
--- a/six-second-100k-two-peers/.gitignore
+++ b/six-second-100k-two-peers/.gitignore
@@ -1,0 +1,5 @@
+go-sbot/
+netsim
+sim-shims/
+ssb-server-db2/
+ssb-server/

--- a/six-second-100k-two-peers/README.md
+++ b/six-second-100k-two-peers/README.md
@@ -1,6 +1,6 @@
 # Six Second Replication
 
-This directory contains three sub-directories with identical netsim test configurations: one tests replications between two `go-sbot` peers; one tests replication with two `ssb-server` peers running `ssb-db`; one tests replication with two `ssb-server` peers running `ssb-db2`.
+This directory contains three sub-directories with identical netsim test configurations: one tests replication between two `go-sbot` peers; one tests replication with two `ssb-server` peers running `ssb-db`; one tests replication with two `ssb-server` peers running `ssb-db2`.
 
 All tests are run against the same fixtures consisting of 100,000 messages from 20 unique authors. Two identities are chosen: one is labelled as `server` and the other as `peer`. The `alloffsets server` netsim command is used to ensure the `server` starts with all 100000 messages. The `peer` is connected to the `server` and a timer is used to measure how many messages are replicated from `server` to `peer` in 6 seconds. A mutual follow is established before connecting the `peer` to the `server` (hence the 10249 message count for `peer` in the test output).
 
@@ -22,7 +22,7 @@ _Note: You may need to make `install.sh` executable by first running `chmod +x i
 
 **Run the simulations**
 
-This script executes the go-go, js-js and js-js (db2) simulations. Output is printed to the terminal. Consider piping the output to a file.
+This script executes the go-go, js-js and js-js (db2) simulations. Output is printed to the terminal.
 
 _Note: You may need to make `simulate.sh` executable by first running `chmod +x simulate.sh`._
 

--- a/six-second-100k-two-peers/README.md
+++ b/six-second-100k-two-peers/README.md
@@ -1,0 +1,41 @@
+# Six Second Replication
+
+This directory contains three sub-directories with identical netsim test configurations: one tests replications between two `go-sbot` peers; one tests replication with two `ssb-server` peers running `ssb-db`; one tests replication with two `ssb-server` peers running `ssb-db2`.
+
+All tests are run against the same fixtures consisting of 100,000 messages from 20 unique authors. Two identities are chosen: one is labelled as `server` and the other as `peer`. The `alloffsets server` netsim command is used to ensure the `server` starts with all 100000 messages. The `peer` is connected to the `server` and a timer is used to measure how many messages are replicated from `server` to `peer` in 6 seconds. A mutual follow is established before connecting the `peer` to the `server` (hence the 10249 message count for `peer` in the test output).
+
+Initial results for this test suite can be viewed [here](https://github.com/ssb-ngi-pointer/netsim-cookbook/issues/2#issuecomment-921696535).
+
+## Prerequisites
+
+You will need the `netsim` binary installed and accessible from the six second replication directory. See the [releases](https://github.com/ssb-ngi-pointer/netsim/releases/tag/v1.0.0) page to download.
+
+## Instructions
+
+**Configure the simulation environment**
+
+This script downloads the fixtures (test data) and care package (ssb implementations) and configures the various implementations for testing.
+
+_Note: You may need to make `install.sh` executable by first running `chmod +x install.sh`._
+
+`./install.sh`
+
+**Run the simulations**
+
+This script executes the go-go, js-js and js-js (db2) simulations. Output is printed to the terminal. Consider piping the output to a file.
+
+_Note: You may need to make `simulate.sh` executable by first running `chmod +x simulate.sh`._
+
+`./simulate.sh`
+
+You may wish to pipe the simulation output to a file for further inspection and archiving:
+
+`./simulate.sh > simulation_log.txt 2>&1`
+
+## Troubleshooting
+
+See the excellent [netsim README](https://github.com/ssb-ngi-pointer/netsim) for comprehensive documentation.
+
+If any errors occur, run the simulation(s) manually with the `verbose` flag (`-v`) to assist with debugging:
+
+`./netsim run -v --spec js-js-db2/netsim-test-6s-100k-js-db2.txt --fixtures fixtures-output ssb-server-db2`

--- a/six-second-100k-two-peers/go-go/netsim-test-6s-100k-go.txt
+++ b/six-second-100k-two-peers/go-go/netsim-test-6s-100k-go.txt
@@ -1,0 +1,28 @@
+comment [ go-go: six second replication with 100k msgs from 100 authors ]
+
+comment [ configuring peer ]
+enter peer
+hops peer 3
+load peer @sWJqvI4hdv96aRMk1pQOJo1frXRFr7oBB5/r/jBMcxw=.ed25519
+
+comment [ configuring server ]
+enter server
+hops server 3
+load server @NZpjhmgTaHOHFZI6G6dIuWwa3UqwSpfRpMbY5ue6vAI=.ed25519
+alloffsets server
+
+comment [ starting go-sbot instances ]
+start server go-sbot
+start peer go-sbot
+
+comment [ creating mutual follow ]
+follow server peer
+follow peer server
+
+wait 10000
+
+comment [ connecting peer to server ]
+timerstart run
+connect peer server
+wait 6000
+timerstop run

--- a/six-second-100k-two-peers/go-go/sim-shim.sh
+++ b/six-second-100k-two-peers/go-go/sim-shim.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+DIR="$1"
+PORT="$2"
+# the following env variables are always set from netsim:
+#   ${CAPS}   the capability key / app key / shs key
+#   ${HOPS}   a integer determining the hops setting for this ssb node
+# if ssb-fixtures are provided, the following variables are also set:
+#   ${LOG_OFFSET}  the location of the log.offset file to be used
+#   ${SECRET}      the location of the secret file which should be copied to the new ssb-dir
+echo "starting go-ssb from ${SCRIPTPATH}"
+
+mkdir -p "${DIR}/log"
+
+if [ -n "${LOG_OFFSET}" ]
+then
+    # log.offset does not exist already -> run fixtures conversion script
+    if [ ! -f ${DIR}/flume/log.offset ]
+    then
+        echo "running with log.offset at ${LOG_OFFSET}; initiating conversion script"
+        # run fixtures conversion script
+        ${SCRIPTPATH}/ssb-offset-converter -if lfo ${LOG_OFFSET} "$DIR/log"
+    else 
+        echo "puppet was started previously, and a ${LOG_OFFSET}-based log.offset already exists"
+    fi
+fi
+
+if [ -n "${SECRET}" ]
+then
+    echo "running with a secret at ${SECRET}"
+    cp ${SECRET} "$DIR/"
+    # set correct perms on secret
+    chmod 600 "$DIR/secret"
+fi
+
+echo "using ports ${PORT} and $(($PORT+1))"
+echo "using caps ${CAPS} and hops ${HOPS}"
+echo "puppet lives in ${DIR}"
+export LIBRARIAN_WRITEALL=0 
+# note: exec is important. otherwise the process won't be killed when the netsim has finished running :)
+#exec ${SCRIPTPATH}/go-sbot -lis :"$PORT" -wslis :"$(($PORT+1))" -repo "$DIR" -shscap "${CAPS}" -hops "${HOPS}"
+exec ${SCRIPTPATH}/go-sbot \
+  -lis :"$PORT" \
+  -wslis "" \
+  -debuglis ":$(($PORT+1))" \
+  -repo "$DIR" \
+  -shscap "${CAPS}" \
+  -hops "$(( ${HOPS} - 1 ))" \
+  -promisc 

--- a/six-second-100k-two-peers/install.sh
+++ b/six-second-100k-two-peers/install.sh
@@ -10,7 +10,7 @@ fi
 echo "[ extracting the fixtures ]"
 tar -xvzf 100k_100auth_fixtures.tar.gz
 
-# check for care pacakge to avoid redownloading
+# check for care package to avoid redownloading
 CARE_PACKAGE=care-package.tar.gz
 if [ ! -f "$CARE_PACKAGE" ]; then
     echo "[ downloading the care package (sbot implementations) ]"

--- a/six-second-100k-two-peers/install.sh
+++ b/six-second-100k-two-peers/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# check for fixtures to avoid redownloading
+FIXTURES=100k_100auth_fixtures.tar.gz
+if [ ! -f "$FIXTURES" ]; then
+    echo "[ downloading the fixtures (test data) ]"
+    wget https://people.iola.dk/anders/100k_100auth_fixtures.tar.gz
+fi
+
+echo "[ extracting the fixtures ]"
+tar -xvzf 100k_100auth_fixtures.tar.gz
+
+# check for care pacakge to avoid redownloading
+CARE_PACKAGE=care-package.tar.gz
+if [ ! -f "$CARE_PACKAGE" ]; then
+    echo "[ downloading the care package (sbot implementations) ]"
+    wget https://github.com/ssb-ngi-pointer/netsim/releases/download/v1.0.0/care-package.tar.gz
+fi
+
+echo "[ extracting the care package ]"
+tar -xvzf care-package.tar.gz --exclude=care-package/ssb-fixtures --strip-components 1
+
+echo "[ copying the ssb-server to the db2 subdirectory ]"
+mkdir ssb-server-db2
+cp -r ssb-server/* ssb-server-db2/
+
+echo "[ configuring the ssb-server (db) ]"
+cp js-js/bin.js ssb-server/bin.js
+cp js-js/sim-shim.sh ssb-server/sim-shim.sh
+cp js-js/package.json ssb-server/package.json
+
+echo "[ installing the ssb-server (db) ]"
+cd ssb-server
+npm install
+cd ..
+
+echo "[ configuring the ssb-server (db2) ]"
+cp js-js-db2/bin.js ssb-server-db2/bin.js
+cp js-js-db2/sim-shim.sh ssb-server-db2/sim-shim.sh
+cp js-js-db2/package.json ssb-server-db2/package.json
+
+echo "[ installing the ssb-server (db2) ]"
+cd ssb-server-db2
+npm install
+cd ..
+
+echo "[ configuring the go-sbot ]"
+cd go-sbot
+# uncomment this line if you wish to extract the apple darwin go-sbot build
+#tar -xvzf go-sbot/darwin-80b8875.tar.gz go-sbot/ --strip-components 1
+# uncomment this line if you wish to extract the linux x64 go-sbot build
+tar -xvzf linux-80b8875.tar.gz --strip-components 1
+cd ..
+cp go-go/sim-shim.sh go-sbot/sim-shim.sh
+
+echo "[ configuration complete ]"

--- a/six-second-100k-two-peers/js-js-db2/bin.js
+++ b/six-second-100k-two-peers/js-js-db2/bin.js
@@ -1,0 +1,40 @@
+#! /usr/bin/env node
+
+// db2
+var SecretStack  = require('secret-stack')
+var caps         = require('ssb-caps')
+var Config       = require('ssb-config/inject')
+var minimist     = require('minimist')
+
+var argv = process.argv.slice(2)
+var i = argv.indexOf('--')
+var conf = argv.slice(i+1)
+argv = ~i ? argv.slice(0, i) : argv
+
+var config = Config(process.env.ssb_appname, minimist(conf))
+config.db2 = { automigrate : true, dangerouslyKillFlumeWhenMigrated : true }
+console.log(config)
+
+if (argv[0] == 'start') {
+  var createSsbServer = SecretStack({ caps })
+    .use(require('ssb-master'))
+    .use(require('ssb-db2'))
+    .use(require('ssb-db2/compat'))
+    .use(require('ssb-lan'))
+    .use(require('ssb-friends'))
+    .use(require('ssb-ebt'))
+    .use(require('ssb-conn'))
+    .use(require('ssb-replicate'))
+    .use(require('ssb-replication-scheduler'))
+
+  // start server
+  var server = createSsbServer(config)
+  // gracefully exit process
+  process.once("SIGINT", function (code) {
+    console.log("sig int received")
+    server.close(true, () => {
+      console.log("exiting")
+      process.exit()
+    })
+  })
+}

--- a/six-second-100k-two-peers/js-js-db2/netsim-test-6s-100k-js-db2.txt
+++ b/six-second-100k-two-peers/js-js-db2/netsim-test-6s-100k-js-db2.txt
@@ -1,0 +1,28 @@
+comment [ js-js (db2): six second replication with 100k msgs from 100 authors ]
+
+comment [ configuring peer ]
+enter peer
+hops peer 3
+load peer @sWJqvI4hdv96aRMk1pQOJo1frXRFr7oBB5/r/jBMcxw=.ed25519
+
+comment [ configuring server ]
+enter server
+hops server 3
+load server @NZpjhmgTaHOHFZI6G6dIuWwa3UqwSpfRpMbY5ue6vAI=.ed25519
+alloffsets server
+
+comment [ starting ssb-server instances ]
+start server ssb-server-db2
+start peer ssb-server-db2
+
+comment [ creating mutual follow ]
+follow server peer
+follow peer server
+
+wait 10000
+
+comment [ connecting peer to server ]
+timerstart run
+connect peer server
+wait 6000
+timerstop run

--- a/six-second-100k-two-peers/js-js-db2/sim-shim.sh
+++ b/six-second-100k-two-peers/js-js-db2/sim-shim.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+DIR="$1"
+PORT="$2"
+WS_PORT=$(("$PORT"+1))
+# the following env variables are always set from netsim:
+#   ${CAPS}   the capability key / app key / shs key
+#   ${HOPS}   a integer determining the hops setting for this ssb node
+# if ssb-fixtures are provided, the following variables are also set:
+#   ${LOG_OFFSET}  the location of the log.offset file to be used
+#   ${SECRET}      the location of the secret file which should be copied to the new ssb-dir
+echo "caps is set to ${CAPS}"
+echo "hops is set to ${HOPS}"
+echo "gossip port: $PORT"
+echo "ws port: $WS_PORT"
+echo "puppet lives in $DIR"
+
+mkdir -p "${DIR}/flume"
+if [ -n "${LOG_OFFSET}" ]
+then
+    # log.offset does not exist already -> copy it over
+    if [ ! -f ${DIR}/flume/log.offset ]
+    then
+        echo "using log offset from ${LOG_OFFSET}"
+        # copy over fixtures
+        cp ${LOG_OFFSET} ${DIR}/flume/log.offset
+    else 
+        echo "puppet was started previously, and a ${LOG_OFFSET}-based log.offset already exists"
+    fi
+fi
+
+if [ -n "${SECRET}" ] 
+then
+    echo "using secret from ${SECRET}"
+    # copy secret
+    cp ${SECRET} "${DIR}/"
+    # set correct perms on secret
+    chmod 600 "$DIR/secret"
+else
+    # TODO: find a better solution for creating a secret file
+    echo "run a hack to generate the secret file.."
+    timeout 0.2 "$SCRIPTPATH"/bin.js start -- --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"
+    # ..so that we can make sure the secret has decent permissions (the go muxrpc-client complains otherwise)
+    chmod 600 "$DIR/secret"
+fi
+
+echo 'starting as DEBUG=* exec "$SCRIPTPATH"/bin.js start -- --no-conn.autostart --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"'
+
+# finally: start the ssb-server with custom ports
+# note: exec is important. otherwise the process won't be killed when the netsim has finished running :)
+#DEBUG=ssb:*,multiserver exec "$SCRIPTPATH"/bin.js start -- --no-conn.autostart --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"
+DEBUG=ssb:* exec "$SCRIPTPATH"/bin.js start -- --no-conn.autostart --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"

--- a/six-second-100k-two-peers/js-js/bin.js
+++ b/six-second-100k-two-peers/js-js/bin.js
@@ -151,10 +151,3 @@ if (argv[0] == 'start') {
     muxrpcli(argv, manifest, rpc, config.verbose)
   })
 }
-
-
-
-
-
-
-

--- a/six-second-100k-two-peers/js-js/bin.js
+++ b/six-second-100k-two-peers/js-js/bin.js
@@ -1,0 +1,160 @@
+#! /usr/bin/env node
+
+var fs           = require('fs')
+var path         = require('path')
+var pull         = require('pull-stream')
+var toPull       = require('stream-to-pull-stream')
+var File         = require('pull-file')
+var explain      = require('explain-error')
+var Config       = require('ssb-config/inject')
+var Client       = require('ssb-client')
+var minimist     = require('minimist')
+var muxrpcli     = require('muxrpcli')
+var cmdAliases   = require('./lib/cli-cmd-aliases')
+var ProgressBar  = require('./lib/progress')
+var packageJson  = require('./package.json')
+
+//get config as cli options after --, options before that are
+//options to the command.
+var argv = process.argv.slice(2)
+var i = argv.indexOf('--')
+var conf = argv.slice(i+1)
+argv = ~i ? argv.slice(0, i) : argv
+
+var config = Config(process.env.ssb_appname, minimist(conf))
+console.log(config)
+
+if (config.keys.curve === 'k256')
+  throw new Error('k256 curves are no longer supported,'+
+                  'please delete' + path.join(config.path, 'secret'))
+
+var manifestFile = path.join(config.path, 'manifest.json')
+
+if (argv[0] == 'server') {
+  console.log('WARNING-DEPRECATION: `sbot server` has been renamed to `ssb-server start`')
+  argv[0] = 'start'
+}
+
+// special start command:
+// import ssbServer and start the server
+if (argv[0] == 'start') {
+  console.log(packageJson.name, packageJson.version, config.path, 'logging.level:'+config.logging.level)
+  console.log('my key ID:', config.keys.public)
+
+  var createSsbServer = require('./')
+    .use(require('ssb-master'))
+    .use(require('ssb-db'))
+    .use(require('ssb-lan'))
+    .use(require('ssb-replicate'))
+    .use(require('ssb-friends'))
+    .use(require('ssb-ebt'))
+    .use(require('ssb-conn'))
+    // .use(require('ssb-promiscuous'))
+    // .use(require('ssb-logging'))
+
+
+  // start server
+  var server = createSsbServer(config)
+  // gracefully exit process
+  process.once("SIGINT", function (code) {
+    console.log("sig int received")
+    server.close(true, () => {
+      console.log("exiting")
+      process.exit()
+    })
+  })
+
+
+  // write RPC manifest to ~/.ssb/manifest.json
+  fs.writeFileSync(manifestFile, JSON.stringify(server.getManifest(), null, 2))
+
+  if(process.stdout.isTTY && (config.logging.level != 'info'))
+    ProgressBar(server.progress)
+} else {
+  // normal command:
+  // create a client connection to the server
+
+  // read manifest.json
+  var manifest
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestFile))
+  } catch (err) {
+    throw explain(err,
+      'no manifest file'
+      + '- should be generated first time server is run'
+    )
+  }
+
+  var opts = {
+    manifest: manifest,
+    port: config.port,
+    host: config.host || 'localhost',
+    caps: config.caps,
+    key: config.key || config.keys.id
+  }
+
+  // connect
+  Client(config.keys, opts, function (err, rpc) {
+    if(err) {
+      if (/could not connect/.test(err.message)) {
+        console.error('Error: Could not connect to ssb-server ' + opts.host + ':' + opts.port)
+        console.error('Use the "start" command to start it.')
+        console.error('Use --verbose option to see full error')
+        if(config.verbose) throw err
+        process.exit(1)
+      }
+      throw err
+    }
+
+    // add aliases
+    for (var k in cmdAliases) {
+      rpc[k] = rpc[cmdAliases[k]]
+      manifest[k] = manifest[cmdAliases[k]]
+    }
+
+    // add some extra commands
+//    manifest.version = 'async'
+    manifest.config = 'sync'
+//    rpc.version = function (cb) {
+//      console.log(packageJson.version)
+//      cb()
+//    }
+    rpc.config = function (cb) {
+      console.log(JSON.stringify(config, null, 2))
+      cb()
+    }
+
+    if (process.argv[2] === 'blobs.add') {
+      var filename = process.argv[3]
+      var source =
+        filename ? File(process.argv[3])
+      : !process.stdin.isTTY ? toPull.source(process.stdin)
+      : (function () {
+        console.error('USAGE:')
+        console.error('  blobs.add <filename> # add a file')
+        console.error('  source | blobs.add   # read from stdin')
+        process.exit(1)
+      })()
+      pull(
+        source,
+        rpc.blobs.add(function (err, hash) {
+          if (err)
+            throw err
+          console.log(hash)
+          process.exit()
+        })
+      )
+      return
+    }
+
+    // run commandline flow
+    muxrpcli(argv, manifest, rpc, config.verbose)
+  })
+}
+
+
+
+
+
+
+

--- a/six-second-100k-two-peers/js-js/netsim-test-6s-100k-js.txt
+++ b/six-second-100k-two-peers/js-js/netsim-test-6s-100k-js.txt
@@ -1,0 +1,28 @@
+comment [ js-js: six second replication with 100k msgs from 100 authors ]
+
+comment [ configuring peer ]
+enter peer
+hops peer 3
+load peer @sWJqvI4hdv96aRMk1pQOJo1frXRFr7oBB5/r/jBMcxw=.ed25519
+
+comment [ configuring server ]
+enter server
+hops server 3
+load server @NZpjhmgTaHOHFZI6G6dIuWwa3UqwSpfRpMbY5ue6vAI=.ed25519
+alloffsets server
+
+comment [ starting ssb-server instances ]
+start server ssb-server
+start peer ssb-server
+
+comment [ creating mutual follow ]
+follow server peer
+follow peer server
+
+wait 10000
+
+comment [ connecting peer to server ]
+timerstart run
+connect peer server
+wait 6000
+timerstop run

--- a/six-second-100k-two-peers/js-js/sim-shim.sh
+++ b/six-second-100k-two-peers/js-js/sim-shim.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+DIR="$1"
+PORT="$2"
+WS_PORT=$(("$PORT"+1))
+# the following env variables are always set from netsim:
+#   ${CAPS}   the capability key / app key / shs key
+#   ${HOPS}   a integer determining the hops setting for this ssb node
+# if ssb-fixtures are provided, the following variables are also set:
+#   ${LOG_OFFSET}  the location of the log.offset file to be used
+#   ${SECRET}      the location of the secret file which should be copied to the new ssb-dir
+echo "caps is set to ${CAPS}"
+echo "hops is set to ${HOPS}"
+echo "gossip port: $PORT"
+echo "ws port: $WS_PORT"
+echo "puppet lives in $DIR"
+
+mkdir -p "${DIR}/flume"
+if [ -n "${LOG_OFFSET}" ]
+then
+    # log.offset does not exist already -> copy it over
+    if [ ! -f ${DIR}/flume/log.offset ]
+    then
+        echo "using log offset from ${LOG_OFFSET}"
+        # copy over fixtures
+        cp ${LOG_OFFSET} ${DIR}/flume/log.offset
+    else 
+        echo "puppet was started previously, and a ${LOG_OFFSET}-based log.offset already exists"
+    fi
+fi
+
+if [ -n "${SECRET}" ] 
+then
+    echo "using secret from ${SECRET}"
+    # copy secret
+    cp ${SECRET} "${DIR}/"
+    # set correct perms on secret
+    chmod 600 "$DIR/secret"
+else
+    # TODO: find a better solution for creating a secret file
+    echo "run a hack to generate the secret file.."
+    timeout 0.2 "$SCRIPTPATH"/bin.js start -- --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"
+    # ..so that we can make sure the secret has decent permissions (the go muxrpc-client complains otherwise)
+    chmod 600 "$DIR/secret"
+fi
+
+echo 'starting as DEBUG=* exec "$SCRIPTPATH"/bin.js start -- --no-conn.autostart --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"'
+
+# finally: start the ssb-server with custom ports
+# note: exec is important. otherwise the process won't be killed when the netsim has finished running :)
+DEBUG=* exec "$SCRIPTPATH"/bin.js start -- --no-conn.autostart --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$DIR" --port "$PORT" --ws.port "$WS_PORT"

--- a/six-second-100k-two-peers/simulate.sh
+++ b/six-second-100k-two-peers/simulate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# execute `./install.sh` to configure everything before running simulations
+
+echo "------------------------------"
+echo "[ running go-sbot simulation ]"
+./netsim run --spec go-go/netsim-test-6s-100k-go.txt --fixtures fixtures-output go-sbot
+
+echo "---------------------------------"
+echo "[ running ssb-server simulation ]"
+./netsim run --spec js-js/netsim-test-6s-100k-js.txt --fixtures fixtures-output ssb-server
+
+echo "---------------------------------------"
+echo "[ running ssb-server (db2) simulation ]"
+./netsim run --spec js-js-db2/netsim-test-6s-100k-js-db2.txt --fixtures fixtures-output ssb-server-db2
+
+echo "----------------------------"
+echo "[ simulation runs complete ]"


### PR DESCRIPTION
Includes six second server -> peer replication simulations for `go-go`, `js-js` and `js-js (db2)`.

`./install.sh`

 - downloads the 100k fixtures
 - downloads the care-package
 - installs and configures the sbot implementations

`./simulate.sh`

 - runs the three netsim tests